### PR TITLE
Fix bug where moving a queen at a border over that border would be considered invalid

### DIFF
--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -191,7 +191,6 @@ public class Board implements Cloneable{
           try{
             Position tmp = step(mover,step,start);
             while(end != tmp && board.get(tmp)==null){
-              tmp = step(mover, step,tmp);
               if(tmp.getColour()!=start.getColour()){//flip steps when moving between board sections.
                 step = new Direction[steps[i].length];
                 for(int j = 0; j<steps[i].length; j++){
@@ -203,6 +202,7 @@ public class Board implements Cloneable{
                   }
                 }
               }
+              tmp = step(mover, step,tmp);
             }
             if(end==tmp) return true;
           }catch(ImpossiblePositionException e){}//do nothing, steps went off board.


### PR DESCRIPTION
Hello,

I found a bug where you can't move a queen thats at the edge of a section over that section without it being considered invalid.
![Screen Shot 2020-09-23 at 4 01 48 Integration](https://user-images.githubusercontent.com/1185881/93984074-f20bf800-fdb5-11ea-9624-4134c7b6c3e0.png)
e.g. I just moved the blue queen from BG4 to RD3, which wouldn't have been possible before this change.

This is because of the moves not being reversed when they should be, but just moving taking the next step to after reversing the move steps fixes it.