### PR TITLE
Class Serialization

### DIFF
--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -1,5 +1,6 @@
 package threeChess;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -9,9 +10,11 @@ import java.util.*;
  * as well as whose move it is, and which pieces have been 
  * captured by which player.
  * **/
-public class Board implements Cloneable{
-
-  /**A map from board positions to the pieces at that position**/
+public class Board implements Cloneable, Serializable {
+  
+  /** Serial version UID for Board serialization and storage**/
+  private static final long serialVersionUID = -8547775276050612530L;
+  /** A map from board positions to the pieces at that position **/
   private HashMap<Position,Piece> board;
   /**A flag that is true if and only if a King has been captured**/
   private boolean gameOver = false;
@@ -404,7 +407,3 @@ public class Board implements Cloneable{
     return clone;
   }
 }
-
-
-
-

--- a/src/threeChess/Piece.java
+++ b/src/threeChess/Piece.java
@@ -1,13 +1,16 @@
 package threeChess;
 
+import java.io.Serializable;
+
 /**
  * A specific piece on the board. 
  * Each piece has a Colour and a Type,
  * and is immutable. 
  * Not an enum so we can have identical, but non-equal pieces, such as pawns. 
  * **/
-public class Piece{
-  private final PieceType type;//the piece's type
+public class Piece implements Serializable {
+  private static final long serialVersionUID = 8757415399259946465L; // Serial version UID for serialization and storage
+  private final PieceType type;// the piece's type
   private final Colour colour;//the pieces colour
 
   /**


### PR DESCRIPTION
Learning agents may choose to store persisted data on disk to retain training information between playing sessions. Depending on the way agents choose to store data, a few of the potential methods require serialization of the Board and Piece classes. This pull request address that need by simply making these classes implement the Serializable interface. Feedback welcome.

Credit to ForsakenIdol