### PR TITLE
Go backwards through the history of the game

### DIFF
--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -118,7 +118,7 @@ public class Board implements Cloneable, Serializable {
       current = next;
     }
     return current;
-  } 
+  }
 
   /**
    * Checks if a move is legal. 

--- a/src/threeChess/CheatBoard.java
+++ b/src/threeChess/CheatBoard.java
@@ -1,7 +1,5 @@
 package threeChess;
 
-import java.util.*;
-
 /**
  * Main class for representing game state.
  * The board maps each position to the piece at that posiiton, 


### PR DESCRIPTION
Hello, in the same spirit of my last PR, this one adds a couple buttons that allow you to cycle through the moves in a game after its over. Once a game is over, or if its waiting for the user to input a manual move, the buttons in the top left and right will appear and allow you to scroll through the history of the game. My agent was making some dumb moves but it was making them fast enough that I didn't have time to see why, so this helps with that.

This builds upon my previous PR a bit so this PR contains its commit as well...
![history](https://user-images.githubusercontent.com/1185881/94448802-ed907680-01dd-11eb-8a96-f57e2943e37a.png)