### PR TITLE
Allow multi-threaded tournaments

### DIFF
--- a/src/threeChess/Agent.java
+++ b/src/threeChess/Agent.java
@@ -10,7 +10,7 @@ package threeChess;
  * Agent########.java, where the hashes correspond to the authors student number;
  * and each Agent must have a zero parameter constructor (but overloaded constructors are allowed). 
  * **/ 
-public abstract class Agent implements Runnable{
+public abstract class Agent implements Runnable, Cloneable {
 
   private Board brd;
   private Position[] mv;
@@ -25,6 +25,11 @@ public abstract class Agent implements Runnable{
   /** Can be overridden to mark an Agent as requiring manual input for moves. **/
   public boolean isAutonomous() {
       return true;
+  }
+
+  /** @return a copy of this agent so that it can be run in another thread. **/
+  public Agent clone() {
+    throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support cloning");
   }
 
   /**

--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -412,6 +412,17 @@ public class Board implements Cloneable, Serializable {
     return timeLeft.get(colour);
   }
 
+  /** @return whether a player timed out. **/
+  public boolean isTimedOut() {
+    if (!gameOver)
+      return false;
+    for(Colour colour : Colour.values()){
+      if(timeLeft.get(colour) < 0)
+        return true;
+    }
+    return false;
+  }
+
   /**
    * Returns a deep clone of the board state, 
    * such that no operations will affect the original board instance.

--- a/src/threeChess/Direction.java
+++ b/src/threeChess/Direction.java
@@ -4,5 +4,29 @@ package threeChess;
  * Enumeration of the rectilinear directions
  * used as the basis for all moves.
  **/
-public enum Direction{FORWARD,BACKWARD,LEFT,RIGHT;}
+public enum Direction {
+    FORWARD,
+    BACKWARD,
+    LEFT,
+    RIGHT;
 
+    /** @return the opposite direction to this direction. **/
+    public Direction reverse() {
+        switch (this) {
+            case FORWARD: return BACKWARD;
+            case BACKWARD: return FORWARD;
+            case LEFT: return RIGHT;
+            case RIGHT: return LEFT;
+            default: throw new UnsupportedOperationException("Unsupported direction " + this);
+        }
+    }
+
+    /** @return a copy of {@param step} with all the directions reversed. **/
+    public static Direction[] reverse(Direction[] step) {
+        Direction[] reversed = new Direction[step.length];
+        for (int index = 0; index < step.length; ++index) {
+            reversed[index] = step[index].reverse();
+        }
+        return reversed;
+    }
+}

--- a/src/threeChess/Game.java
+++ b/src/threeChess/Game.java
@@ -1,0 +1,306 @@
+package threeChess;
+
+import threeChess.agents.GUIAgent;
+import threeChess.agents.RandomAgent;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Holds the state to simulate a three-chess game.
+ */
+public class Game implements Runnable {
+
+  /** A random agent used to have a valid move to pass to the board when an agent times out. **/
+  private static final RandomAgent randomAgent = new RandomAgent();
+  /** The additional delay allowed for the executor being slow when executing moves. **/
+  private static final int ADDITIONAL_DELAY_ALLOWANCE_MS = 3000;
+
+  /** Represents the status of the game. **/
+  public enum GameStatus {
+    RUNNING, GAME_OVER, TIMED_OUT, HIT_MAX_TURNS, ILLEGAL_MOVE
+  }
+
+  private final Agent[] agents;
+  private final int timeLimitSeconds;
+  private final boolean isTimed;
+  private final int maximumTurns;
+  private final int pauseMS;
+  private final PrintStream logger;
+
+  private final Board board;
+  private final ThreeChessDisplay display;
+  private final AtomicReference<GameStatus> status = new AtomicReference<>();
+  private int[] scores;
+
+  /**
+   * Constructs a threeChess game between three players.
+   *
+   * @param agents a length 3 array of the agents to play the game, in order of blue, green, and then red.
+   * @param timeLimitSeconds the cumulative time each player has (in seconds).
+   *                         To specify an untimed game, set as less than or equal to zero.
+   * @param maximumTurns the maximum number of turns to play before deciding the game is a draw.
+   *                     To specify no maximum, set to less than or equal to zero.
+   * @param pauseMS the minimum amount of time to wait in milliseconds between each turn.
+   * @param logger a printStream to write the game moves to.
+   * @param displayOn a boolean flag for whether the game should be graphically displayed
+   */
+  public Game(
+      Agent[] agents, int timeLimitSeconds, int maximumTurns,
+      int pauseMS, PrintStream logger, boolean displayOn) {
+
+    if (agents.length != 3)
+      throw new IllegalArgumentException();
+
+    this.agents = agents;
+    this.timeLimitSeconds = timeLimitSeconds;
+    this.isTimed = (timeLimitSeconds > 0);
+    this.maximumTurns = maximumTurns;
+    this.pauseMS = pauseMS;
+    this.logger = logger;
+
+    board = new Board(isTimed ? 1000 * timeLimitSeconds : 1);
+    if (displayOn) {
+      display = new ThreeChessDisplay(board, agents[0].toString(), agents[1].toString(), agents[2].toString());
+      GUIAgent.currentDisplay = display;
+    } else {
+      display = null;
+    }
+    status.set(GameStatus.RUNNING);
+
+    log("======NEW GAME======");
+    log("BLUE: " + agents[0]);
+    log("GREEN: " + agents[1]);
+    log("RED: " + agents[2]);
+  }
+
+  /** @return the status of this game. **/
+  public GameStatus getStatus() {
+    return status.get();
+  }
+
+  /** @return a length-3 array of the final score for each agent in the order blue, green, red. **/
+  public int[] getAgentScores() {
+    if (status.get() == GameStatus.RUNNING)
+      throw new IllegalStateException("Game is not over!");
+
+    return scores;
+  }
+
+  /** @return a length-3 array of the time spent in milliseconds for each agent in the order blue, green, red. **/
+  public int[] getAgentTimes() {
+    int[] times = new int[3];
+    for (Colour colour : Colour.values()) {
+      times[colour.ordinal()] = 1000 * timeLimitSeconds - board.getTimeLeft(colour);
+    }
+    return times;
+  }
+
+  /** @return the agents that are playing in this game. **/
+  public Agent[] getAgents() {
+    return agents;
+  }
+
+  /** Updates the status of this game to a game over status. **/
+  private void endGame(GameStatus status, int[] scores) {
+    if (status == GameStatus.RUNNING)
+      throw new IllegalStateException("Can not end the game with status " + status);
+
+    this.scores = scores;
+    this.status.set(status);
+
+    repaint();
+    GUIAgent.currentDisplay = null;
+
+    log("=====Game Over=====");
+    for (Colour colour : Colour.values()) {
+      int score = scores[colour.ordinal()];
+      int timeLeft = board.getTimeLeft(colour);
+      log(colour + " - score: " + score + ", time:" + timeLeft);
+    }
+  }
+
+  /** Plays out the whole game. **/
+  @Override
+  public void run() {
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    executor.allowCoreThreadTimeOut(true);
+
+    try {
+      playGame(executor);
+
+      // Sanity check.
+      if (status.get() == GameStatus.RUNNING)
+        throw new IllegalStateException();
+    } finally {
+      executor.shutdownNow();
+
+      try {
+        // Wait for the executor service to shutdown.
+        if (!executor.awaitTermination(15, TimeUnit.SECONDS)) {
+          System.err.println("Executor service is not terminating, is there an infinite loop in an agent?");
+        }
+      } catch (InterruptedException e) {
+        // Preserve interrupt status.
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /** Plays out the whole game. **/
+  public void playGame(ExecutorService executor) {
+    if (status.get() != GameStatus.RUNNING)
+      throw new IllegalStateException("Game is not running! Has status " + status);
+    if (board.gameOver())
+      throw new IllegalStateException("Board is showing gameOver, yet status is " + status);
+
+    // Keep looping until game over.
+    while (true) {
+      long start = System.nanoTime();
+
+      // Play one turn.
+      Colour turnColour = board.getTurn();
+      Agent agent = agents[turnColour.ordinal()];
+      playTurn(executor, turnColour, agent);
+
+      // Check if the status has changed from running.
+      if (status.get() != GameStatus.RUNNING)
+        break;
+
+      // Check for game over.
+      if (board.gameOver()) {
+        GameStatus status = (board.isTimedOut() ? GameStatus.TIMED_OUT : GameStatus.GAME_OVER);
+        int[] scores = {0, 0, 0};
+        scores[board.getWinner().ordinal()] = 1;
+        scores[board.getLoser().ordinal()] = -1;
+        endGame(status, scores);
+        break;
+      }
+
+      // Check for hitting maximum turns.
+      if (maximumTurns > 0 && board.getMoveCount() >= maximumTurns) {
+        int[] scores = {0, 0, 0};
+        endGame(GameStatus.HIT_MAX_TURNS, scores);
+        break;
+      }
+
+      // Pause as much time as needed to make the length of this turn at least pauseMS.
+      long durationMS = (System.nanoTime() - start + 500_000L) / 1_000_000L;
+      long pauseTimeMS = pauseMS - durationMS;
+      if (agent.isAutonomous() && display != null && pauseTimeMS > 0) {
+        try {
+          Thread.sleep(pauseTimeMS);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  /** @return a clone of the current board of the game. **/
+  private Board cloneBoard() {
+    try {
+      return (Board) board.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Plays one turn of the game. **/
+  public void playTurn(ExecutorService executor, Colour turnColour, Agent agent) {
+    if (status.get() != GameStatus.RUNNING)
+      throw new IllegalStateException("Game is not running! Has status " + status);
+
+    // Submit the move to be decided in a separate thread.
+    AgentPlayMoveTask task = new AgentPlayMoveTask(agent, cloneBoard());
+    AgentPlayMoveResult result;
+    try {
+      Future<AgentPlayMoveResult> future = executor.submit(task);
+
+      // Get the resulting move the agent decided, being careful of timeouts.
+      if (isTimed) {
+        long timeRemainingMS = board.getTimeLeft(turnColour);
+        try {
+          result = future.get(timeRemainingMS + ADDITIONAL_DELAY_ALLOWANCE_MS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+          future.cancel(true);
+
+          // The agent timed out trying to decide its move, give it a random move.
+          log(turnColour + " agent " + agent + " TIMED OUT");
+          Position[] move = randomAgent.playMove(cloneBoard());
+          result = new AgentPlayMoveResult(move, timeRemainingMS + ADDITIONAL_DELAY_ALLOWANCE_MS);
+        }
+      } else {
+        result = future.get();
+      }
+    } catch (ExecutionException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    // Get the move and duration from the result object.
+    Position[] move = result.move;
+    long durationMS = result.durationMS;
+
+    // Check if it was an illegal move, and if so end the game.
+    if (move == null || move.length != 2 || !board.isLegalMove(move[0], move[1])) {
+      log("INVALID MOVE: " + Arrays.toString(move));
+      int[] scores = {1, 1, 1};
+      scores[turnColour.ordinal()] = -2;
+      endGame(GameStatus.ILLEGAL_MOVE, scores);
+      return;
+    }
+
+    // Play the move on the board.
+    try {
+      board.move(move[0], move[1], (int) durationMS);
+      log(turnColour + ": " + move[0] + '-' + move[1] + " t:" + durationMS);
+      repaint();
+    } catch (ImpossiblePositionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** If this Game has a logger, println's the given log. **/
+  private void log(String log) {
+    if (logger != null) {
+      logger.println(log);
+    }
+  }
+
+  /** If there is a display, repaints it. **/
+  private void repaint() {
+    if (display != null) {
+      display.repaintCanvas();
+    }
+  }
+
+  /** The result of a AgentPlayMoveTask. **/
+  private static class AgentPlayMoveResult {
+    public final Position[] move;
+    public final long durationMS;
+    private AgentPlayMoveResult(Position[] move, long durationMS) {
+      this.move = move;
+      this.durationMS = durationMS;
+    }
+  }
+
+  /** A task that can be submitted to an executor service to get an agent to play a move. **/
+  private static class AgentPlayMoveTask implements Callable<AgentPlayMoveResult> {
+    private final Agent agent;
+    private final Board board;
+    private AgentPlayMoveTask(Agent agent, Board board) {
+      this.agent = agent;
+      this.board = board;
+    }
+    @Override
+    public AgentPlayMoveResult call() {
+      long startTimeNanos = System.nanoTime();
+      Position[] move = agent.playMove(board);
+      long durationNanos = System.nanoTime() - startTimeNanos;
+      long durationMS = (durationNanos + 500_000L) / 1_000_000L;
+      return new AgentPlayMoveResult(move, durationMS);
+    }
+  }
+}

--- a/src/threeChess/Tournament.java
+++ b/src/threeChess/Tournament.java
@@ -1,0 +1,283 @@
+package threeChess;
+
+import java.io.PrintStream;
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * Runs a tournament between a set of agents.
+ */
+public class Tournament {
+
+  /** Used to randomly select agents for games. **/
+  private static final Random random = new Random();
+  /** The interval in seconds between the tournament reporting how many games have finished. **/
+  private static final int SECONDS_PER_REPORT = 10;
+
+  private final Agent[] agents;
+  private final int numGames;
+  private final int timeLimitSeconds;
+  private final int maximumTurns;
+  private final int pauseMS;
+  private final int threads;
+  private final PrintStream logger;
+  private final boolean displayOn;
+
+  private final ThreadPoolExecutor executor;
+
+  private final Map<Agent, AgentStats> stats = new HashMap<>();
+
+  /**
+   * @param agents the agents to be tested.
+   *
+   * @param numGames the number of games in total to be played.
+   *
+   * @param timeLimitSeconds the time limit in seconds for each agent in each game.
+   *                         If this is set to zero, there is no time limit.
+   *
+   * @param maximumTurns the maximum number of turns before aborting each game.
+   *                     If this is set to zero, there is no turn limit.
+   *
+   * @param pauseMS the minimum amount of time to spend for each turn in the game.
+   *
+   * @param threads the number of threads to run games on.
+   *
+   * @param logger the logger to print the output of the tournament to.
+   *
+   * @param displayOn whether to create a display for each of the games.
+   */
+  public Tournament(
+      Agent[] agents, int numGames, int timeLimitSeconds, int maximumTurns,
+      int pauseMS, int threads, PrintStream logger, boolean displayOn) {
+
+    if (agents.length < 3)
+      throw new IllegalArgumentException();
+    if (threads < 1)
+      throw new IllegalArgumentException();
+
+    this.agents = agents;
+    this.numGames = numGames;
+    this.timeLimitSeconds = timeLimitSeconds;
+    this.maximumTurns = maximumTurns;
+    this.pauseMS = pauseMS;
+    this.threads = threads;
+    this.logger = logger;
+    this.displayOn = displayOn;
+
+    if (threads > 1) {
+      executor = new ThreadPoolExecutor(threads, threads, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+      executor.allowCoreThreadTimeOut(true);
+    } else {
+      executor = null;
+    }
+
+    for (Agent agent : agents) {
+      if (stats.put(agent, new AgentStats(agent)) != null)
+        throw new IllegalArgumentException("Duplicate entry for agent " + agent);
+    }
+  }
+
+  /** @return the stats for each agent, ordered in descending order. **/
+  public List<AgentStats> getDescendingStats() {
+    List<AgentStats> agentStats = new ArrayList<>(stats.values());
+    Collections.sort(agentStats);
+    return agentStats;
+  }
+
+  /** Runs this tournament. **/
+  public void runTournament() {
+    // Suppress game output when threaded.
+    PrintStream gameLogger = (threads > 1 ? null : logger);
+
+    // Generate all of the games to be played.
+    List<Game> gamesToPlay = new ArrayList<>();
+    for (int i=0; i < numGames; ++i) {
+      gamesToPlay.add(selectGame(gameLogger));
+    }
+    logger.println("Starting tournament with " + gamesToPlay.size() + " games");
+
+    // Run all of the games.
+    if (threads > 1) {
+      runGamesThreaded(gamesToPlay);
+    } else {
+      for (Game game : gamesToPlay) {
+        game.run();
+      }
+    }
+
+    // Accumulate the statistics of all the games.
+    for (Game game : gamesToPlay) {
+      Game.GameStatus status = game.getStatus();
+      Agent[] agents = game.getAgents();
+      int[] scores = game.getAgentScores();
+      int[] times = game.getAgentTimes();
+      for (Colour colour : Colour.values()) {
+        Agent agent = agents[colour.ordinal()];
+
+        int score = scores[colour.ordinal()];
+        AgentStats agentStats = stats.get(agent);
+        int time = times[colour.ordinal()];
+        agentStats.update(score, status, time);
+      }
+    }
+
+    // Print the statistics of all the agents.
+    List<AgentStats> agentStats = new ArrayList<>(new HashSet<>(stats.values()));
+    Collections.sort(agentStats);
+    logger.println();
+    for (AgentStats agentStat : agentStats) {
+      logger.println(agentStat);
+    }
+  }
+
+  /** Runs all of the games threaded. **/
+  private void runGamesThreaded(List<Game> gamesToPlay) {
+    if (executor == null)
+      throw new IllegalStateException();
+
+    List<Future<?>> futures = new ArrayList<>();
+    for (Game game : gamesToPlay) {
+      futures.add(executor.submit(game));
+    }
+
+    // Wait for all of the games to finish, giving periodic updates.
+    int reportCountdown = SECONDS_PER_REPORT;
+    while (futures.size() > 0) {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+
+      // Remove the futures that have finished execution.
+      Iterator<Future<?>> iter = futures.iterator();
+      while (iter.hasNext()) {
+        Future<?> future = iter.next();
+        if (future.isDone()) {
+          iter.remove();
+          // Print exceptions that occurred in the future.
+          try {
+            future.get();
+          } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+          }
+        }
+      }
+
+      if (--reportCountdown <= 0 || futures.isEmpty()) {
+        reportCountdown = SECONDS_PER_REPORT;
+        logger.println((gamesToPlay.size() - futures.size()) + " / " + gamesToPlay.size() + " games completed");
+      }
+    }
+  }
+
+  /** @return a random game to be played. **/
+  private Game selectGame(PrintStream logger) {
+    // Select 3 random agents.
+    List<Agent> availableAgents = new ArrayList<>(Arrays.asList(agents));
+    Agent[] agents = {
+        selectAndRemoveRandomAgent(availableAgents),
+        selectAndRemoveRandomAgent(availableAgents),
+        selectAndRemoveRandomAgent(availableAgents)
+    };
+
+    // Copy the agents and link them back to their original agents.
+    for (int index = 0; index < agents.length; ++index) {
+      Agent original = agents[index];
+      Agent clone = original.clone();
+      agents[index] = clone;
+      stats.put(clone, stats.get(original));
+    }
+
+    return new Game(agents, timeLimitSeconds, maximumTurns, pauseMS, logger, displayOn);
+  }
+
+  /** @return a random agent from {@param availableAgents} that gets removed from the list. **/
+  private static Agent selectAndRemoveRandomAgent(List<Agent> availableAgents) {
+    int index = random.nextInt(availableAgents.size());
+    return availableAgents.remove(index);
+  }
+
+  /** Holds the statistics for a given agent. **/
+  public static class AgentStats implements Comparable<AgentStats> {
+    public final Agent agent;
+    public int won = 0;
+    public int lost = 0;
+    public int timedOut = 0;
+    public int illegalMoves = 0;
+    public int draws = 0;
+    public int turnedOut = 0;
+    public int games = 0;
+    public int totalTimeMilliseconds = 0;
+
+    public AgentStats(Agent agent) {
+      this.agent = agent;
+    }
+
+    /** Updates the stats of this agent with a score from a game. **/
+    public void update(int score, Game.GameStatus status, int timeMS) {
+      games += 1;
+      totalTimeMilliseconds += timeMS;
+      if (score > 0) {
+        won += score;
+      } else if (score < 0) {
+        lost -= score;
+        switch (status) {
+          case TIMED_OUT:
+            timedOut += 1;
+            break;
+          case ILLEGAL_MOVE:
+            illegalMoves += 1;
+            break;
+          default:
+            break;
+        }
+      } else {
+        draws += 1;
+        if (status == Game.GameStatus.HIT_MAX_TURNS) {
+          turnedOut += 1;
+        }
+      }
+    }
+
+    /** @return an average score for this agent. **/
+    public double average() {
+      if (games == 0)
+        return 0;
+      return (double) (won - lost) / games;
+    }
+
+    @Override
+    public String toString() {
+      double avg = Math.round(average() * 100.0d) / 100.0d;
+      double seconds = Math.round((double) totalTimeMilliseconds / games / 10.0d) / 100.0d;
+      return pad(agent.toString(), 20, 3)
+          + pad("avg: " + avg + ",", 14, 2)
+          + pad("won: " + won + ",", 10, 2)
+          + pad("draw: " + draws + ",", 11, 2)
+          + pad("lost: " + lost + ",", 11, 2)
+          + pad("timed-out: " + timedOut + ",", 16, 2)
+          + pad("illegal-moves: " + illegalMoves + ",", 20, 2)
+          + pad("hit-max-turns: " + turnedOut + ",", 20, 2)
+          + pad("games: " + games, 12, 2)
+          + pad("time: " + seconds, 13, 2);
+    }
+
+    @Override
+    public int compareTo(AgentStats other) {
+      return Double.compare(other.average(), average());
+    }
+  }
+
+  /** Pads after the given string with zeroes until it is at least the given length. **/
+  private static String pad(String str, int length, int minimumPad) {
+    StringBuilder builder = new StringBuilder(str);
+    while (builder.length() < length) {
+      builder.append(' ');
+    }
+    for (int i=0; i<minimumPad; ++i) {
+      builder.append(' ');
+    }
+    return builder.toString();
+  }
+}

--- a/src/threeChess/agents/RandomAgent.java
+++ b/src/threeChess/agents/RandomAgent.java
@@ -20,7 +20,11 @@ public class RandomAgent extends Agent{
    * A no argument constructor, 
    * required for tournament management.
    * **/
-  public RandomAgent(){
+  public RandomAgent(){}
+
+  /** @return another equivalent random agent. **/
+  @Override public RandomAgent clone() {
+    return new RandomAgent();
   }
 
   /**


### PR DESCRIPTION
Hello,

To test my agents I was wanting to run games quicker, so I made this to allow running multiple games at once over multiple threads. It also gives more in-depth statistics for each tournament, and it never plays an agent against itself.

Thought this might be useful to allow people more time in the tournament, or for other people's testing as well.

Here's an example output when running a tournament:
```
Starting tournament with 10000 games
985 / 10000 games completed
2712 / 10000 games completed
4423 / 10000 games completed
6178 / 10000 games completed
8149 / 10000 games completed
10000 / 10000 games completed

Greedy                 avg: 0.62,      won: 5004,  draw: 2166,  lost: 332,   timed-out: 0,     illegal-moves: 0,     hit-max-turns: 0,     games: 7502   time: 0.01     
Greedy                 avg: 0.61,      won: 4819,  draw: 2230,  lost: 327,   timed-out: 0,     illegal-moves: 0,     hit-max-turns: 0,     games: 7376   time: 0.01     
Random                 avg: -0.6,      won: 93,    draw: 2793,  lost: 4615,  timed-out: 0,     illegal-moves: 0,     hit-max-turns: 0,     games: 7501   time: 0.0      
Random                 avg: -0.61,     won: 84,    draw: 2811,  lost: 4726,  timed-out: 0,     illegal-moves: 0,     hit-max-turns: 0,     games: 7621   time: 0.0      
```

This is quite a big commit, although most of it is equivalent to your tournament and game code, just with some changes to allow for the threading.

EDIT: Oh this also adds the greedy agent, was just kinda weird having a tournament with only random agents for the example above.

Cheers,
~Paddy L.