### PR TITLE
Add getBoard(), (immutablly) to Board.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ doc/
 
 #agent code
 src/threeChess/agents/
+/.idea/.gitignore
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/threeChess.iml
+/threeChess.iml
+/.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,3 @@ doc/
 
 #agent code
 src/threeChess/agents/
-/.idea/.gitignore
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/threeChess.iml
-/threeChess.iml
-/.idea/vcs.xml

--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -413,16 +413,12 @@ public class Board implements Cloneable, Serializable {
   }
 
   /**
-   * Return the map representing the current board state, wrapped to be unmodifiable.
+   * Return a copy of map representing the current board state
    *
-   * IMPORTANT NOTE: While you can not modify the returned Map, changes to the board (such as move()),
-   * will be reflected in this returned map, so if you wish to keep this around for caching or something,
-   * you should create a copy of it by using: new HashMap<>(board.getPositionPieceMap)
-   *
-   * @return The unmodifiable (though not immutable, see Note) board position/piece state map
+   * @return The copy of the board position/piece state map
    */
-  public Map<Position, Piece> getPositionPieceMap() {
-    return Collections.unmodifiableMap(board);
+  public HashMap<Position, Piece> getPositionPieceMap() {
+    return new HashMap<>(board);
   }
 
   /**

--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -413,10 +413,15 @@ public class Board implements Cloneable, Serializable {
   }
 
   /**
-   * Return the map representing the current board state, wrapped to be unmodifiable
-   * @return The unmodifiable board state map
+   * Return the map representing the current board state, wrapped to be unmodifiable.
+   *
+   * IMPORTANT NOTE: While you can not modify the returned Map, changes to the board (such as move()),
+   * will be reflected in this returned map, so if you wish to keep this around for caching or something,
+   * you should create a copy of it by using: new HashMap<>(board.getPositionPieceMap)
+   *
+   * @return The unmodifiable (though not immutable, see Note) board position/piece state map
    */
-  public Map<Position, Piece> getBoard() {
+  public Map<Position, Piece> getPositionPieceMap() {
     return Collections.unmodifiableMap(board);
   }
 

--- a/src/threeChess/Board.java
+++ b/src/threeChess/Board.java
@@ -413,6 +413,14 @@ public class Board implements Cloneable, Serializable {
   }
 
   /**
+   * Return the map representing the current board state, wrapped to be unmodifiable
+   * @return The unmodifiable board state map
+   */
+  public Map<Position, Piece> getBoard() {
+    return Collections.unmodifiableMap(board);
+  }
+
+  /**
    * Returns a deep clone of the board state, 
    * such that no operations will affect the original board instance.
    * @return a deep clone of the board state.


### PR DESCRIPTION
This adds a helper method to Board.java to allow you to access the game board (though not change it) for use in things such as caching based on the board state.